### PR TITLE
run apt-get update after adding ondrej/php

### DIFF
--- a/build/php/Dockerfile
+++ b/build/php/Dockerfile
@@ -12,8 +12,9 @@ RUN apt-get update \
 
     && apt-get install -y curl zip unzip git software-properties-common \
     && add-apt-repository -y ppa:ondrej/php \
-    && apt-get install -y php-fpm php-cli php-mcrypt php-gd php-mysql \
-       php-pgsql php-imap php-memcached php-mbstring php-xml \
+    && apt-get update \
+    && apt-get install -y php7.0-fpm php7.0-cli php7.0-mcrypt php7.0-gd php7.0-mysql \
+       php7.0-pgsql php7.0-imap php7.0-memcached php7.0-mbstring php7.0-xml \
     && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && mkdir /run/php \
     && apt-get remove -y --purge software-properties-common \


### PR DESCRIPTION
As it is now, php is installed via the ubuntu repo still. (unless I am misunderstanding something...)