### PR TITLE
Fixed an error on the Dockerfile

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -31,7 +31,7 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 ADD default /etc/nginx/sites-available/default
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 ADD php-fpm.conf /etc/php/7.2/fpm/php-fpm.conf
-ADD start-container.sh /usr/bin/start-container
+ADD start-container /usr/bin/start-container
 RUN chmod +x /usr/bin/start-container
 
 ENTRYPOINT ["start-container"]


### PR DESCRIPTION
Following the **Get the files and spin up containers** i got an error saying
```
Step 10/12 : ADD start-container.sh /usr/bin/start-container
ERROR: Service 'app' failed to build: ADD failed: stat /var/lib/docker/tmp/docker-builder283264189/start-container.sh: no such file or directory
```

The script is called `start-container` not `start-container.sh`!
Can fix it by using the actual file name (which doesn't have `.sh` ext)